### PR TITLE
Added abstract-section extension for Quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,10 @@ quarto use template tockudex/nmbu-quarto-typst-thesis-template
 
 Inside of the template directory, you will find the markdown file `thesis.qmd`, which you can use as a starting place for writing your thesis.
 
+A `.qmd` file is composed of a `YAML` header and a `markdown` body. The former contains `keys` that set parameters applying to your body and metadata (author name, published date, etc.). Most keys used in this template are annotated, so you can easily adjust them to your needs. The body of a Quarto document is written in a slightly [modified markdown version](https://quarto.org/docs/authoring/markdown-basics.html).
+
+### Abstract section
+
+In published papers and reports, the abstract is often placed right after the title and prior to the table of contents (toc) and introduction. In a Quarto document, the `toc` appears before any other heading (abstract, introduction, etc.). In order to place the abstract before the `toc`, you can comment out (remove the pound/hash sign) `abstract-section` from the `filters` key in the YAML header. Upon recompilation, your abstract will appear before your `toc`.
+
 _TODO_: Better describe how to use this format (typst files, etc.).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ quarto use template tockudex/nmbu-quarto-typst-thesis-template
 
 Inside of the template directory, you will find the markdown file `thesis.qmd`, which you can use as a starting place for writing your thesis.
 
-A `.qmd` file is composed of a `YAML` header and a `markdown` body. The former contains `keys` that set parameters applying to your body and metadata (author name, published date, etc.). Most keys used in this template are annotated, so you can easily adjust them to your needs. The body of a Quarto document is written in a slightly [modified markdown version](https://quarto.org/docs/authoring/markdown-basics.html).
+A `.qmd` file is composed of a `YAML` header and a `markdown` body. The former contains `keys` that set parameters applying to your body and metadata (author name, published date, etc.). Most keys used in this template are annotated, so you can easily adjust them to your needs. The body of a Quarto document is written in a slightly [modified markdown](https://quarto.org/docs/authoring/markdown-basics.html).
 
 ### Abstract section
 

--- a/_extensions/pandoc-ext/abstract-section/_extension.yaml
+++ b/_extensions/pandoc-ext/abstract-section/_extension.yaml
@@ -1,0 +1,6 @@
+title: abstract-section
+author: Albert Krewinkel
+version: 1.2.0
+contributes:
+  filters:
+    - abstract-section.lua

--- a/_extensions/pandoc-ext/abstract-section/abstract-section.lua
+++ b/_extensions/pandoc-ext/abstract-section/abstract-section.lua
@@ -1,0 +1,85 @@
+--[[
+abstract-section – move an "abstract" section into document metadata
+
+Copyright: © 2017–2023 Albert Krewinkel
+License:   MIT – see LICENSE file for details
+]]
+local stringify = (require 'pandoc.utils').stringify
+local section_identifiers = {
+  abstract = true,
+}
+local collected = {}
+--- The level of the highest heading that was seen so far. Abstracts
+--- must be at or above this level to prevent nested sections from being
+--- treated as metadata. Only top-level sections should become metadata.
+local toplevel = 6
+
+--- Extract abstract from a list of blocks.
+local function abstract_from_blocklist (blocks)
+  local body_blocks = {}
+  local looking_at_section = false
+
+  for _, block in ipairs(blocks) do
+    if block.t == 'Header' and block.level <= toplevel then
+      toplevel = block.level
+      if section_identifiers[block.identifier] then
+        looking_at_section = block.identifier
+        collected[looking_at_section] = {}
+      else
+        looking_at_section = false
+        body_blocks[#body_blocks + 1] = block
+      end
+    elseif looking_at_section then
+      if block.t == 'HorizontalRule' then
+        looking_at_section = false
+      else
+        local collect = collected[looking_at_section]
+        collect[#collect + 1] = block
+      end
+    else
+      body_blocks[#body_blocks + 1] = block
+    end
+  end
+
+  return body_blocks
+end
+
+Pandoc = function (doc)
+  local meta = doc.meta
+
+  -- configure
+  section_identifiers_list =
+    (doc.meta['abstract-section'] or {})['section-identifiers']
+  if section_identifiers_list and #section_identifiers_list > 0 then
+    section_identifiers = {}
+    for i, ident in ipairs(section_identifiers_list) do
+      section_identifiers[stringify(ident)] = true
+    end
+  end
+  -- unset config in meta
+  doc.meta['abstract-section'] = nil
+
+  local blocks = {}
+  if PANDOC_VERSION >= {2,17} then
+    -- Walk all block lists by default
+    blocks = doc.blocks:walk{Blocks = abstract_from_blocklist}
+  elseif PANDOC_VERSION >= {2,9,2} then
+    -- Do the same with pandoc versions that don't have walk methods but the
+    -- `walk_block` function.
+    blocks = pandoc.utils.walk_block(
+      pandoc.Div(doc.blocks),
+      {Blocks = abstract_from_blocklist}
+    ).content
+  else
+    -- otherwise, just check the top-level block-list
+    blocks = abstract_from_blocklist(doc.blocks)
+  end
+  for metakey in pairs(section_identifiers) do
+    metakey = stringify(metakey)
+    local abstract = collected[metakey]
+    if not meta[metakey] and abstract and #abstract > 0 then
+      meta[metakey] = pandoc.MetaBlocks(abstract)
+    end
+  end
+  return pandoc.Pandoc(blocks, meta)
+end

--- a/template.qmd
+++ b/template.qmd
@@ -2,6 +2,13 @@
 title: Untitled
 format:
   nmbu-thesis-template-typst: default
+
+# Places a table of contents after your title
+toc: true
+
+#filters:
+  # Places the abstract before the table of contents
+  #- abstract-section
 ---
 
 ## Introduction


### PR DESCRIPTION
Hi,

[This extension](https://github.com/pandoc-ext/abstract-section) makes it possible to place an abstract section in the body of the `.qmd` body (the section is defined by a heading containing "Abstract"), while placing in before the Table of Content in the compiled PDF.

For it to work, the YAML key `filters` needs to be set to `abstract-session`. If you want to place the abstract anywhere after the ToC, just unset/uncomment the `filters` key. This is described in the `README.md`.

Partially solves #2.